### PR TITLE
Add the ASDF version manager plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A curated list of awesome tools, prompts and other cool nuggets for the amazing 
 - [Fundle](https://github.com/tuvistavie/fundle)
 
 ## Plugins
+- [ASDF](https://github.com/doughsay/omf-asdf) - ASDF version manager plugin.
 - [Bass](https://github.com/edc/bass) - Make Bash utilities usable in fish.
 - [Debug](https://github.com/fisherman/debug) - Conditional debug logger.
 - [DockerCompose](https://github.com/brgmnn/fish-docker-compose) - Docker Compose Autocompletions.


### PR DESCRIPTION
The [ASDF](https://github.com/asdf-vm/asdf) version manager is the
version manager to end all version managers. No more
rbenv/rvm/nvm/exenv/etc...

This is a simple plugin I created that installs asdf for you and adds
all the proper linking and completions for you. (if you're using
oh-my-fish).